### PR TITLE
fix(viewmodel): correct anchor handling; validate custom cycles; inject clock

### DIFF
--- a/lib/models/subscription.dart
+++ b/lib/models/subscription.dart
@@ -3,6 +3,8 @@ import 'package:subscription_manager/models/billing_cycle.dart';
 
 part 'subscription.g.dart';
 
+const _unset = Object();
+
 @HiveType(typeId: 0)
 class Subscription {
   @HiveField(0)
@@ -37,6 +39,7 @@ class Subscription {
 
   @HiveField(10)
   final int? billingAnchorDay;
+
   const Subscription({
     required this.id,
     required this.serviceName,
@@ -58,11 +61,11 @@ class Subscription {
     String? currency,
     BillingCycle? billingCycle,
     DateTime? nextRenewalDate,
-    String? category,
-    String? notes,
-    String? cancellationUrl,
-    int? customCycleDays,
-    int? billingAnchorDay,
+    Object? category = _unset,
+    Object? notes = _unset,
+    Object? cancellationUrl = _unset,
+    Object? customCycleDays = _unset,
+    Object? billingAnchorDay = _unset,
   }) {
     return Subscription(
       id: id ?? this.id,
@@ -71,11 +74,18 @@ class Subscription {
       currency: currency ?? this.currency,
       billingCycle: billingCycle ?? this.billingCycle,
       nextRenewalDate: nextRenewalDate ?? this.nextRenewalDate,
-      category: category ?? this.category,
-      notes: notes ?? this.notes,
-      cancellationUrl: cancellationUrl ?? this.cancellationUrl,
-      customCycleDays: customCycleDays ?? this.customCycleDays,
-      billingAnchorDay: billingAnchorDay ?? this.billingAnchorDay,
+      category:
+          identical(category, _unset) ? this.category : category as String?,
+      notes: identical(notes, _unset) ? this.notes : notes as String?,
+      cancellationUrl: identical(cancellationUrl, _unset)
+          ? this.cancellationUrl
+          : cancellationUrl as String?,
+      customCycleDays: identical(customCycleDays, _unset)
+          ? this.customCycleDays
+          : customCycleDays as int?,
+      billingAnchorDay: identical(billingAnchorDay, _unset)
+          ? this.billingAnchorDay
+          : billingAnchorDay as int?,
     );
   }
 }

--- a/test/utils/rollover_test.dart
+++ b/test/utils/rollover_test.dart
@@ -111,4 +111,285 @@ void main() {
       expect(next, DateTime(2025, 2, 28, 8, 30));
     });
   });
+
+  group('rollForward (multi-step / far-in-the-past)', () {
+    test('monthly multi-step: rolls to nearest future just beyond now', () {
+      final start = DateTime(2023, 1, 31, 10, 15);
+      final now = DateTime(2023, 12, 15, 9, 00);
+
+      final next = rollForward(
+        start: start,
+        cycle: BillingCycle.monthly,
+        anchorDay: 31,
+        now: now,
+      );
+
+      expect(next, DateTime(2023, 12, 31, 10, 15));
+      expect(next.isAfter(now), isTrue);
+    });
+
+    test('custom multi-step: finds the first slot after now', () {
+      final start = DateTime(2025, 1, 1, 9, 0);
+      final now = DateTime(2025, 1, 20, 9, 0);
+      final next = rollForward(
+        start: start,
+        cycle: BillingCycle.custom,
+        customCycleDays: 7,
+        now: now,
+      );
+      expect(next, DateTime(2025, 1, 22, 9, 0));
+    });
+  });
+
+  group('rollForward (monthly invariant over a whole year)', () {
+    test('keeps anchor or clamps to month-end; preserves hh:mm:ss.mmm', () {
+      final start = DateTime(2025, 1, 31, 7, 45, 12, 345);
+      var current = start;
+      var now = DateTime(2025, 1, 1);
+
+      for (var i = 0; i < 12; i++) {
+        final next = rollForward(
+          start: current,
+          cycle: BillingCycle.monthly,
+          anchorDay: 31,
+          now: now,
+        );
+        final lastDay = DateTime(next.year, next.month + 1, 0).day;
+        expect(next.day, anyOf(31, lastDay), reason: 'month=${next.month}');
+        expect(next.hour, 7);
+        expect(next.minute, 45);
+        expect(next.second, 12);
+        expect(next.millisecond, 345);
+
+        now = next;
+        current = next;
+      }
+    });
+  });
+
+  group('rollForward (anchorDay ignored for non-monthly/yearly)', () {
+    final start = DateTime(2025, 3, 30, 10, 00);
+
+    test('daily ignores anchorDay', () {
+      final next = rollForward(
+        start: start,
+        cycle: BillingCycle.daily,
+        anchorDay: 31,
+        now: start,
+      );
+      expect(next, start.add(const Duration(days: 1)));
+    });
+
+    test('weekly ignores anchorDay', () {
+      final next = rollForward(
+        start: start,
+        cycle: BillingCycle.weekly,
+        anchorDay: 1,
+        now: start,
+      );
+      expect(next, start.add(const Duration(days: 7)));
+    });
+
+    test('custom ignores anchorDay', () {
+      final next = rollForward(
+        start: start,
+        cycle: BillingCycle.custom,
+        customCycleDays: 10,
+        anchorDay: 15,
+        now: start,
+      );
+      expect(next, start.add(const Duration(days: 10)));
+    });
+  });
+
+  group('rollForward (strictly future relative to now)', () {
+    final base = DateTime(2025, 5, 10, 12, 0);
+
+    test('daily is strictly after now', () {
+      final next =
+          rollForward(start: base, cycle: BillingCycle.daily, now: base);
+      expect(next.isAfter(base), isTrue);
+      expect(next.isAtSameMomentAs(base), isFalse);
+    });
+
+    test('weekly is strictly after now', () {
+      final next =
+          rollForward(start: base, cycle: BillingCycle.weekly, now: base);
+      expect(next.difference(base), const Duration(days: 7));
+      expect(next.isAfter(base), isTrue);
+    });
+
+    test('monthly (anchor=null) uses start.day and is after now', () {
+      final next =
+          rollForward(start: base, cycle: BillingCycle.monthly, now: base);
+      expect(next.day, base.day);
+      expect(next.isAfter(base), isTrue);
+    });
+
+    test('yearly (anchor=null) uses start.day (clamped) and is after now', () {
+      final next =
+          rollForward(start: base, cycle: BillingCycle.yearly, now: base);
+      expect(next.month, base.month);
+      final lastDay = DateTime(next.year, next.month + 1, 0).day;
+      expect(next.day, anyOf(base.day, lastDay));
+      expect(next.isAfter(base), isTrue);
+    });
+  });
+
+  group(
+      'rollForward (yearly preserves anchor and returns to Feb-29 on leap years)',
+      () {
+    test('2024-02-29 -> 2025-02-28 -> 2026-02-28 -> 2027-02-28 -> 2028-02-29',
+        () {
+      final start = DateTime(2024, 2, 29, 8, 30);
+
+      final y2025 = rollForward(
+        start: start,
+        cycle: BillingCycle.yearly,
+        anchorDay: 29,
+        now: start,
+      );
+      expect(y2025, DateTime(2025, 2, 28, 8, 30));
+
+      final y2026 = rollForward(
+        start: y2025,
+        cycle: BillingCycle.yearly,
+        anchorDay: 29,
+        now: y2025,
+      );
+      expect(y2026, DateTime(2026, 2, 28, 8, 30));
+
+      final y2027 = rollForward(
+        start: y2026,
+        cycle: BillingCycle.yearly,
+        anchorDay: 29,
+        now: y2026,
+      );
+      expect(y2027, DateTime(2027, 2, 28, 8, 30));
+
+      final y2028 = rollForward(
+        start: y2027,
+        cycle: BillingCycle.yearly,
+        anchorDay: 29,
+        now: y2027,
+      );
+      expect(y2028, DateTime(2028, 2, 29, 8, 30));
+    });
+  });
+
+  group('rollForward (monthly returns to 31 after 30-clamp)', () {
+    test('2025-04-30 -> 2025-05-31 with anchor=31', () {
+      final apr30 = DateTime(2025, 4, 30, 10, 15);
+      final may = rollForward(
+        start: apr30,
+        cycle: BillingCycle.monthly,
+        anchorDay: 31,
+        now: apr30,
+      );
+      expect(may, DateTime(2025, 5, 31, 10, 15));
+    });
+  });
+
+  group('rollForward (monthly start 29 across feb)', () {
+    test('2025-01-29 -> 2025-02-28 -> 2025-03-29 (non-leap)', () {
+      final jan29 = DateTime(2025, 1, 29, 9, 0);
+      final feb = rollForward(
+        start: jan29,
+        cycle: BillingCycle.monthly,
+        anchorDay: 29,
+        now: jan29,
+      );
+      final mar = rollForward(
+        start: feb,
+        cycle: BillingCycle.monthly,
+        anchorDay: 29,
+        now: feb,
+      );
+      expect(feb, DateTime(2025, 2, 28, 9, 0));
+      expect(mar, DateTime(2025, 3, 29, 9, 0));
+    });
+
+    test('2024-01-29 -> 2024-02-29 -> 2024-03-29 (leap)', () {
+      final jan29 = DateTime(2024, 1, 29, 9, 0);
+      final feb = rollForward(
+        start: jan29,
+        cycle: BillingCycle.monthly,
+        anchorDay: 29,
+        now: jan29,
+      );
+      final mar = rollForward(
+        start: feb,
+        cycle: BillingCycle.monthly,
+        anchorDay: 29,
+        now: feb,
+      );
+      expect(feb, DateTime(2024, 2, 29, 9, 0));
+      expect(mar, DateTime(2024, 3, 29, 9, 0));
+    });
+  });
+
+  group('rollForward (yearly invariant on non-feb months)', () {
+    test('anchor=15 keeps day across years', () {
+      final start = DateTime(2023, 7, 15, 8, 30);
+      final y1 = rollForward(
+          start: start, cycle: BillingCycle.yearly, anchorDay: 15, now: start);
+      final y2 = rollForward(
+          start: y1, cycle: BillingCycle.yearly, anchorDay: 15, now: y1);
+      final y3 = rollForward(
+          start: y2, cycle: BillingCycle.yearly, anchorDay: 15, now: y2);
+      expect(y1, DateTime(2024, 7, 15, 8, 30));
+      expect(y2, DateTime(2025, 7, 15, 8, 30));
+      expect(y3, DateTime(2026, 7, 15, 8, 30));
+    });
+
+    test('anchor=31 stays safe in same month', () {
+      final start = DateTime(2023, 8, 31, 6, 0);
+      final y1 = rollForward(
+          start: start, cycle: BillingCycle.yearly, anchorDay: 31, now: start);
+      final y2 = rollForward(
+          start: y1, cycle: BillingCycle.yearly, anchorDay: 31, now: y1);
+      expect(y1, DateTime(2024, 8, 31, 6, 0));
+      expect(y2, DateTime(2025, 8, 31, 6, 0));
+    });
+  });
+
+  group('rollForward (yearly without anchor uses start.day)', () {
+    test('start on 2023-02-29 equivalent clamps to 28 and stays until leap',
+        () {
+      final start = DateTime(2024, 2, 29, 7, 45);
+      final y1 =
+          rollForward(start: start, cycle: BillingCycle.yearly, now: start);
+      final y2 = rollForward(start: y1, cycle: BillingCycle.yearly, now: y1);
+      final y3 = rollForward(start: y2, cycle: BillingCycle.yearly, now: y2);
+      final y4 = rollForward(start: y3, cycle: BillingCycle.yearly, now: y3);
+      expect(y1, DateTime(2025, 2, 28, 7, 45));
+      expect(y2, DateTime(2026, 2, 28, 7, 45));
+      expect(y3, DateTime(2027, 2, 28, 7, 45));
+      expect(y4,
+          anyOf(DateTime(2028, 2, 28, 7, 45), DateTime(2028, 2, 29, 7, 45)));
+    });
+  });
+
+  group('rollForward (strict future when start > now)', () {
+    test('returns strictly after now when start is already in the future', () {
+      final start = DateTime(2025, 5, 10, 12, 0);
+      final now = start.subtract(const Duration(hours: 1));
+      final next = rollForward(
+          start: start, cycle: BillingCycle.monthly, anchorDay: 10, now: now);
+      expect(next.isAfter(now), isTrue);
+      expect(next.isAtSameMomentAs(now), isFalse);
+    });
+  });
+
+  group('rollForward (idempotency for same now)', () {
+    test('calling twice with same now does not jump twice', () {
+      final base = DateTime(2025, 1, 31, 9, 0);
+      final now = DateTime(2025, 1, 31, 9, 0);
+      final n1 = rollForward(
+          start: base, cycle: BillingCycle.monthly, anchorDay: 31, now: now);
+      final n2 = rollForward(
+          start: n1, cycle: BillingCycle.monthly, anchorDay: 31, now: now);
+      expect(n2, n1);
+    });
+  });
 }

--- a/test/viewmodels/subscription_list_viewmodel_flow_test.dart
+++ b/test/viewmodels/subscription_list_viewmodel_flow_test.dart
@@ -1,0 +1,372 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:subscription_manager/viewmodels/subscription_list_viewmodel.dart';
+import 'package:subscription_manager/data/subscription_repository.dart';
+import 'package:subscription_manager/data/settings_repository.dart';
+import 'package:subscription_manager/models/app_settings.dart';
+import 'package:subscription_manager/services/notification_service.dart';
+import 'package:subscription_manager/models/subscription.dart';
+import 'package:subscription_manager/models/billing_cycle.dart';
+import 'package:subscription_manager/utils/rollover.dart';
+import 'package:subscription_manager/l10n/app_localizations.dart';
+
+class MockSubRepo extends Mock implements SubscriptionRepository {}
+
+class MockSettingsRepo extends Mock implements SettingsRepository {}
+
+class MockNotif extends Mock implements NotificationService {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(Subscription(
+      id: 'x',
+      serviceName: 'x',
+      cost: 1,
+      currency: 'EUR',
+      billingCycle: BillingCycle.monthly,
+      nextRenewalDate: DateTime(2025, 1, 1),
+    ));
+  });
+
+  test('load() rolls past-due to future, updates repo, reschedules all',
+      () async {
+    final repo = MockSubRepo();
+    final settings = MockSettingsRepo();
+    final notif = MockNotif();
+
+    final past = Subscription(
+      id: 'p1',
+      serviceName: 'Past',
+      cost: 5,
+      currency: 'EUR',
+      billingCycle: BillingCycle.monthly,
+      nextRenewalDate: DateTime(2023, 1, 31, 9, 0),
+      billingAnchorDay: 31,
+    );
+
+    when(() => repo.getAll()).thenReturn([past]);
+    Subscription? updatedCaptured;
+    when(() => repo.update(any<Subscription>())).thenAnswer((inv) async {
+      updatedCaptured = inv.positionalArguments.first as Subscription;
+    });
+    when(() => settings.current).thenReturn(const AppSettings());
+
+    Iterable<Subscription>? rescheduled;
+    final vm = SubscriptionListViewModel(
+      repo: repo,
+      settingsRepo: settings,
+      notificationService: notif,
+      rescheduler: (subs) async {
+        rescheduled = subs.toList();
+      },
+    );
+
+    await vm.load();
+
+    expect(vm.items, isNotEmpty);
+    expect(updatedCaptured, isNotNull);
+    expect(
+        updatedCaptured!.nextRenewalDate
+            .isAfter(DateTime.now().subtract(const Duration(days: 1))),
+        isTrue);
+    expect(rescheduled, isNotNull);
+    expect(rescheduled!.length, 1);
+  });
+
+  test('add() sets anchor for monthly/yearly and schedules notification',
+      () async {
+    final repo = MockSubRepo();
+    final settings = MockSettingsRepo();
+    final notif = MockNotif();
+
+    when(() => repo.add(any<Subscription>())).thenAnswer((_) async {});
+    when(() => repo.getAll()).thenReturn([]);
+    when(() => settings.current).thenReturn(
+        const AppSettings(leadDays: 2, notifyHour: 9, notifyMinute: 30));
+    when(() => notif.scheduleRenewalReminder(
+          subscriptionId: any(named: 'subscriptionId'),
+          title: any(named: 'title'),
+          body: any(named: 'body'),
+          renewalDate: any(named: 'renewalDate'),
+          leadDays: any(named: 'leadDays'),
+          notifyHour: any(named: 'notifyHour'),
+          notifyMinute: any(named: 'notifyMinute'),
+        )).thenAnswer((_) async {});
+
+    final vm = SubscriptionListViewModel(
+      repo: repo,
+      settingsRepo: settings,
+      notificationService: notif,
+      rescheduler: (_) async {},
+    );
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+
+    await vm.add(
+      serviceName: 'S',
+      cost: 10,
+      currency: 'EUR',
+      cycle: BillingCycle.monthly,
+      nextRenewal: DateTime(2025, 5, 31, 8, 0),
+      l10n: l10n,
+    );
+
+    expect(vm.items.single.billingAnchorDay, 31);
+    verify(() => notif.scheduleRenewalReminder(
+          subscriptionId: any(named: 'subscriptionId'),
+          title: any(named: 'title'),
+          body: any(named: 'body'),
+          renewalDate: DateTime(2025, 5, 31, 8, 0),
+          leadDays: 2,
+          notifyHour: 9,
+          notifyMinute: 30,
+        )).called(1);
+  });
+
+  test('update() cycle transitions adjust anchor and reschedule', () async {
+    final repo = MockSubRepo();
+    final settings = MockSettingsRepo();
+    final notif = MockNotif();
+
+    final s = Subscription(
+      id: 'u1',
+      serviceName: 'S',
+      cost: 3,
+      currency: 'EUR',
+      billingCycle: BillingCycle.monthly,
+      nextRenewalDate: DateTime(2025, 1, 31, 9, 0),
+      billingAnchorDay: 31,
+    );
+
+    when(() => repo.getAll()).thenReturn([s]);
+    when(() => repo.update(any<Subscription>())).thenAnswer((_) async {});
+    when(() => settings.current).thenReturn(const AppSettings());
+    when(() => notif.cancelForSubscription(any())).thenAnswer((_) async {});
+    when(() => notif.scheduleRenewalReminder(
+          subscriptionId: any(named: 'subscriptionId'),
+          title: any(named: 'title'),
+          body: any(named: 'body'),
+          renewalDate: any(named: 'renewalDate'),
+          leadDays: any(named: 'leadDays'),
+          notifyHour: any(named: 'notifyHour'),
+          notifyMinute: any(named: 'notifyMinute'),
+        )).thenAnswer((_) async {});
+
+    final vm = SubscriptionListViewModel(
+      repo: repo,
+      settingsRepo: settings,
+      notificationService: notif,
+      rescheduler: (_) async {},
+    );
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+
+    await vm.load();
+
+    await vm.update(
+      s.copyWith(
+        billingCycle: BillingCycle.yearly,
+        nextRenewalDate: DateTime(2025, 2, 28, 9, 0),
+        billingAnchorDay: null,
+      ),
+      l10n,
+    );
+    expect(vm.items.single.billingAnchorDay, 31);
+
+    await vm.update(
+      vm.items.single.copyWith(
+        billingCycle: BillingCycle.custom,
+        nextRenewalDate: vm.items.single.nextRenewalDate,
+        customCycleDays: 10,
+      ),
+      l10n,
+    );
+    expect(vm.items.single.billingAnchorDay, isNull);
+
+    await vm.update(
+      vm.items.single.copyWith(
+        billingCycle: BillingCycle.monthly,
+        nextRenewalDate: DateTime(2025, 6, 15, 9, 0),
+      ),
+      l10n,
+    );
+    expect(vm.items.single.billingAnchorDay, 15);
+
+    verify(() => notif.cancelForSubscription(any()))
+        .called(greaterThanOrEqualTo(1));
+    verify(() => notif.scheduleRenewalReminder(
+          subscriptionId: any(named: 'subscriptionId'),
+          title: any(named: 'title'),
+          body: any(named: 'body'),
+          renewalDate: any(named: 'renewalDate'),
+          leadDays: any(named: 'leadDays'),
+          notifyHour: any(named: 'notifyHour'),
+          notifyMinute: any(named: 'notifyMinute'),
+        )).called(greaterThanOrEqualTo(1));
+  });
+
+  test('remove() and undoLastDelete() manage repo, list and notifications',
+      () async {
+    final repo = MockSubRepo();
+    final settings = MockSettingsRepo();
+    final notif = MockNotif();
+
+    final s = Subscription(
+      id: 'r1',
+      serviceName: 'S',
+      cost: 3,
+      currency: 'EUR',
+      billingCycle: BillingCycle.monthly,
+      nextRenewalDate: DateTime(2025, 1, 31, 9, 0),
+      billingAnchorDay: 31,
+    );
+
+    when(() => repo.getAll()).thenReturn([s]);
+    when(() => repo.update(any<Subscription>())).thenAnswer((_) async {});
+    when(() => repo.remove(any())).thenAnswer((_) async {});
+    when(() => repo.add(any<Subscription>())).thenAnswer((_) async {});
+    when(() => settings.current).thenReturn(const AppSettings());
+    when(() => notif.cancelForSubscription(any())).thenAnswer((_) async {});
+    when(() => notif.scheduleRenewalReminder(
+          subscriptionId: any(named: 'subscriptionId'),
+          title: any(named: 'title'),
+          body: any(named: 'body'),
+          renewalDate: any(named: 'renewalDate'),
+          leadDays: any(named: 'leadDays'),
+          notifyHour: any(named: 'notifyHour'),
+          notifyMinute: any(named: 'notifyMinute'),
+        )).thenAnswer((_) async {});
+
+    final vm = SubscriptionListViewModel(
+      repo: repo,
+      settingsRepo: settings,
+      notificationService: notif,
+      rescheduler: (_) async {},
+    );
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+
+    await vm.load();
+    expect(vm.items.length, 1);
+
+    await vm.removeWithMemory('r1');
+    expect(vm.items, isEmpty);
+    verify(() => repo.remove('r1')).called(1);
+    verify(() => notif.cancelForSubscription('r1')).called(1);
+
+    await vm.undoLastDelete(l10n);
+    expect(vm.items.length, 1);
+    verify(() => repo.add(any<Subscription>())).called(1);
+    verify(() => notif.scheduleRenewalReminder(
+          subscriptionId: any(named: 'subscriptionId'),
+          title: any(named: 'title'),
+          body: any(named: 'body'),
+          renewalDate: any(named: 'renewalDate'),
+          leadDays: any(named: 'leadDays'),
+          notifyHour: any(named: 'notifyHour'),
+          notifyMinute: any(named: 'notifyMinute'),
+        )).called(1);
+  });
+
+  test('replaceAllFromImport() removes old, adds new, schedules all', () async {
+    final repo = MockSubRepo();
+    final settings = MockSettingsRepo();
+    final notif = MockNotif();
+
+    final old = Subscription(
+      id: 'o1',
+      serviceName: 'Old',
+      cost: 1,
+      currency: 'EUR',
+      billingCycle: BillingCycle.monthly,
+      nextRenewalDate: DateTime(2025, 1, 31, 9, 0),
+      billingAnchorDay: 31,
+    );
+
+    final new1 = Subscription(
+      id: 'n1',
+      serviceName: 'New1',
+      cost: 2,
+      currency: 'EUR',
+      billingCycle: BillingCycle.yearly,
+      nextRenewalDate: DateTime(2025, 7, 15, 9, 0),
+      billingAnchorDay: 15,
+    );
+
+    final new2 = Subscription(
+      id: 'n2',
+      serviceName: 'New2',
+      cost: 3,
+      currency: 'EUR',
+      billingCycle: BillingCycle.custom,
+      nextRenewalDate: DateTime(2025, 3, 10, 9, 0),
+      customCycleDays: 10,
+      billingAnchorDay: null,
+    );
+
+    when(() => repo.getAll()).thenReturn([old]);
+    when(() => repo.update(any<Subscription>())).thenAnswer((_) async {});
+    when(() => repo.remove(any())).thenAnswer((_) async {});
+    when(() => repo.add(any<Subscription>())).thenAnswer((_) async {});
+    when(() => settings.current).thenReturn(const AppSettings());
+    when(() => notif.cancelForSubscription(any())).thenAnswer((_) async {});
+    when(() => notif.scheduleRenewalReminder(
+          subscriptionId: any(named: 'subscriptionId'),
+          title: any(named: 'title'),
+          body: any(named: 'body'),
+          renewalDate: any(named: 'renewalDate'),
+          leadDays: any(named: 'leadDays'),
+          notifyHour: any(named: 'notifyHour'),
+          notifyMinute: any(named: 'notifyMinute'),
+        )).thenAnswer((_) async {});
+
+    final vm = SubscriptionListViewModel(
+      repo: repo,
+      settingsRepo: settings,
+      notificationService: notif,
+      rescheduler: (_) async {},
+    );
+
+    await vm.load();
+    await vm.replaceAllFromImport([new1, new2]);
+
+    verify(() => repo.remove('o1')).called(1);
+    verify(() => repo.add(any<Subscription>())).called(2);
+    verify(() => notif.scheduleRenewalReminder(
+          subscriptionId: any(named: 'subscriptionId'),
+          title: any(named: 'title'),
+          body: any(named: 'body'),
+          renewalDate: any(named: 'renewalDate'),
+          leadDays: any(named: 'leadDays'),
+          notifyHour: any(named: 'notifyHour'),
+          notifyMinute: any(named: 'notifyMinute'),
+        )).called(2);
+  });
+
+  test('yearly anchor=29 survives clamp and returns to Feb-29 by 2028',
+      () async {
+    final s = Subscription(
+      id: 'z1',
+      serviceName: 'Z',
+      cost: 1,
+      currency: 'EUR',
+      billingCycle: BillingCycle.yearly,
+      nextRenewalDate: DateTime(2024, 2, 29, 8, 30),
+      billingAnchorDay: 29,
+    );
+    final y2025 = rollForward(
+        start: s.nextRenewalDate,
+        cycle: BillingCycle.yearly,
+        anchorDay: s.billingAnchorDay,
+        now: s.nextRenewalDate);
+    final y2026 = rollForward(
+        start: y2025, cycle: BillingCycle.yearly, anchorDay: 29, now: y2025);
+    final y2027 = rollForward(
+        start: y2026, cycle: BillingCycle.yearly, anchorDay: 29, now: y2026);
+    final y2028 = rollForward(
+        start: y2027, cycle: BillingCycle.yearly, anchorDay: 29, now: y2027);
+    expect(y2025, DateTime(2025, 2, 28, 8, 30));
+    expect(y2028, DateTime(2028, 2, 29, 8, 30));
+  });
+}


### PR DESCRIPTION
### Unify `billingAnchorDay`, deterministic clock, validation & tests

Make anchor rules explicit and consistent, validate custom cycles early, inject a testable clock, and expand coverage. No schema or API breaks.

### Summary
- **Anchor policy**
  - **Monthly/Yearly** → keep previous `billingAnchorDay` if present; otherwise default to `nextRenewalDate.day`.
  - **Daily/Weekly/Custom** → set `billingAnchorDay` to `null`.
- **Validation**: in `add()` / `update()`, throw `ArgumentError` when `billingCycle == custom` and `customCycleDays == null || customCycleDays <= 0`.
- **Deterministic time**: introduce `nowProvider` (defaults to `DateTime.now`) and use it in `load()` for reproducible behavior and stable tests.
- **Model**: sentinel-based `copyWith` for nullable fields (`category`, `notes`, `cancellationUrl`, `customCycleDays`, `billingAnchorDay`) to distinguish “not provided” vs “explicitly null”.
- **Notifications**: `addFromImport()` now schedules renewal reminders (consistent with `add()`).
- **Tests**: expanded coverage; all tests green.

### Motivation
- Manual reconstruction in `update()` was brittle and risked losing fields as the model evolves.
- Anchor logic across cycle transitions was implicit and inconsistent.
- `customCycleDays` errors surfaced deep inside `rollForward`, yielding poor diagnostics.
- `load()` used raw `DateTime.now()`, causing flakiness around EoM/DST and in unit tests.

### Changes
**ViewModel**
- Unified anchor handling via `copyWith`.
- Early validation for `customCycleDays`.
- Injected clock (`nowProvider`) and used it in `load()` and tests.
- `addFromImport()` schedules notifications.

**Model**
- Sentinel-based `copyWith` for nullable fields to cleanly support “clear to null” vs “leave unchanged”.

**Tests**
- ViewModel: cycle transitions (preserve/clear anchor), validation, flows (`remove/undo`, `replaceAllFromImport`).
- Rollover: EoM clamp, leap years (incl. Feb-29 return), multi-step catch-up, `hh:mm:ss.mmm` invariants, idempotency, “return to 31 after 30-clamp”.

### Key Snippet
    final isAnchored = updated.billingCycle == BillingCycle.monthly ||
                       updated.billingCycle == BillingCycle.yearly;

    final oldIdx = _items.indexWhere((e) => e.id == updated.id);
    final oldAnchor = oldIdx >= 0 ? _items[oldIdx].billingAnchorDay : null;

    final targetAnchor = isAnchored
        ? (oldAnchor ?? updated.nextRenewalDate.day)
        : null;

    final withAnchor = updated.copyWith(billingAnchorDay: targetAnchor);

### Manual QA
- [ ] Monthly from **Jan-31** → switch to **custom(10)** → `billingAnchorDay == null`; `rollForward` preserves time-of-day.  
- [ ] **Custom → Yearly**: anchor preserved (or defaults to `nextRenewal.day` if absent).  
- [ ] **Yearly**, anchor=29 on **2024-02-29** → 2025/26/27 clamp to **Feb-28**; **2028** returns to **Feb-29**.  
- [ ] `addFromImport()` schedules notifications; `replaceAllFromImport()` remains consistent.  
- [ ] `load()` advances overdue renewals and triggers reschedule using the injected clock.

### Compatibility / Risk
- **Breaking changes:** none  
- **Public API surface:** unchanged  
- **Data migration:** none (Hive schema unchanged)  
- **Performance:** no regressions expected; logic simpler  
- **Security/PII:** none  
- **Logging/Telemetry:** unchanged  
- **Rollback:** revert PR; data compatibility preserved

### How to verify locally
    flutter test --coverage
    genhtml coverage/lcov.info -o coverage/html
    # macOS: open coverage/html/index.html
    # Linux: xdg-open coverage/html/index.html

### Commits (Sep 22, 2025)
- `refactor(model): implement sentinel-based copyWith for nullable fields` — *jurate-vilima*  
- `feat(viewmodel): inject clock, validate custom cycles, and unify anch…` — *jurate-vilima*  
- `test(viewmodel): cover anchor transitions, flow, and custom cycle val…` — *jurate-vilima*  
- `test(rollover): expand coverage (EoM clamp, leap years, multi-step, i…` — *jurate-vilima*
